### PR TITLE
Fix:  exclude products that aren't being manufactured yet

### DIFF
--- a/bags-inventory.js
+++ b/bags-inventory.js
@@ -16,7 +16,11 @@ export async function calculateBagsInventory() {
   let bagsMessage, bagsQuantityMessage;
 
   for (const product of productList) {
-    if (product["__EMPTY_12"] === "ORDENAR") {
+    if (
+      product["__EMPTY_12"] === "ORDENAR" &&
+      product["__EMPTY_3"] && // Initial order must not be 0...
+      product["__EMPTY_4"] // ...and incoming cannot be 0
+    ) {
       bagsToReorder.push(product["__EMPTY"]);
       quantityRemaining.push(product["__EMPTY_4"]);
     }

--- a/boxes-inventory.js
+++ b/boxes-inventory.js
@@ -16,7 +16,11 @@ export async function calculateBoxesInventory() {
   let boxesMessage, boxesQuantityMessage;
 
   for (const product of productList) {
-    if (product["__EMPTY_12"] === "REORDER") {
+    if (
+      product["__EMPTY_12"] === "REORDER" &&
+      product["__EMPTY_3"] !== 0 && // Initial order must not be 0...
+      product["__EMPTY_4"] !== 0 // ...and incoming cannot be 0
+    ) {
       boxesToReorder.push(product["__EMPTY"]);
       quantityRemaining.push(product["__EMPTY_4"]);
     }

--- a/flavors-inventory.js
+++ b/flavors-inventory.js
@@ -15,7 +15,11 @@ export async function calculateFlavorsInventory() {
   let flavorsMessage, flavorsQuantityRemaining;
 
   for (const product of productList) {
-    if (product["__EMPTY_10"] === "ORDENAR") {
+    if (
+      product["__EMPTY_10"] === "ORDENAR" &&
+      product["__EMPTY_3"] !== 0 && // Initial order must not be 0...
+      product["__EMPTY_4"] !== 0 // ...and incoming cannot be 0
+    ) {
       flavorsToReorder.push(product["__EMPTY"]);
       quantityRemaining.push(product["__EMPTY_4"]);
     }


### PR DESCRIPTION
The initial Slack alert was including items that we have zero inventory of and not prepared to keep track of yet.  We'll keep it in the inventory spreadsheet for visibility but keep it out of the alert.