### PR TITLE
Fix:  add toLocaleString() method to product quantities

### DIFF
--- a/bags-inventory.js
+++ b/bags-inventory.js
@@ -29,7 +29,7 @@ export async function calculateBagsInventory() {
   if (!bagsToReorder.length) return;
 
   bagsMessage = bagsToReorder.join("\n");
-  const finalBags = quantityRemaining.map((q) => q.toString() + " bags");
+  const finalBags = quantityRemaining.map((q) => q.toLocaleString() + " bags");
   bagsQuantityMessage = finalBags.join("\n");
 
   return { bagsToReorder, bagsMessage, bagsQuantityMessage };

--- a/boxes-inventory.js
+++ b/boxes-inventory.js
@@ -29,7 +29,9 @@ export async function calculateBoxesInventory() {
   if (!boxesToReorder.length) return;
 
   boxesMessage = boxesToReorder.join("\n");
-  const finalBoxes = quantityRemaining.map((q) => q.toString() + " boxes");
+  const finalBoxes = quantityRemaining.map(
+    (q) => q.toLocaleString() + " boxes"
+  );
   boxesQuantityMessage = finalBoxes.join("\n");
 
   return { boxesToReorder, boxesMessage, boxesQuantityMessage };

--- a/flavors-inventory.js
+++ b/flavors-inventory.js
@@ -29,7 +29,7 @@ export async function calculateFlavorsInventory() {
 
   flavorsMessage = flavorsToReorder.join("\n");
   const finalFlavors = quantityRemaining.map(
-    (q) => q.toString() + " containers"
+    (q) => q.toLocaleString() + " containers"
   );
   flavorsQuantityRemaining = finalFlavors.join("\n");
 


### PR DESCRIPTION
Add the `toLocaleString()` method to product quantities so they include commas in the Slack alert.